### PR TITLE
Fix for issue https://github.com/DCMLab/ABC/issues/19

### DIFF
--- a/MS3/n09op59-3_02.mscx
+++ b/MS3/n09op59-3_02.mscx
@@ -11988,20 +11988,6 @@ Op.59 No.3, 2nd movement</b></text>
           <Chord>
             <dots>1</dots>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <Slur>
-                <SlurSegment no="0">
-                  <o4 x="-7.30984" y="-0.310323"/>
-                  </SlurSegment>
-                <up>down</up>
-                </Slur>
-              <next>
-                <location>
-                  <measures>1</measures>
-                  <fractions>-3/8</fractions>
-                  </location>
-                </next>
-              </Spanner>
             <Note>
               <pitch>76</pitch>
               <tpc>18</tpc>
@@ -12019,20 +12005,33 @@ Op.59 No.3, 2nd movement</b></text>
             <fractions>3/8</fractions>
             </location>
           <Chord>
-            <dots>1</dots>
+            <offset x="-2.5" y="0"/>
             <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <SlurSegment no="0">
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
             <Note>
               <pitch>76</pitch>
               <tpc>18</tpc>
               </Note>
             </Chord>
-          </voice>
-        <voice>
-          <location>
-            <fractions>5/8</fractions>
-            </location>
           <Chord>
             <durationType>eighth</durationType>
+              <Spanner type="Slur">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
             <StemDirection>down</StemDirection>
             <Note>
               <pitch>74</pitch>
@@ -12049,14 +12048,6 @@ Op.59 No.3, 2nd movement</b></text>
           <Chord>
             <BeamMode>no</BeamMode>
             <durationType>quarter</durationType>
-            <Spanner type="Slur">
-              <prev>
-                <location>
-                  <measures>-1</measures>
-                  <fractions>3/8</fractions>
-                  </location>
-                </prev>
-              </Spanner>
             <StemDirection>down</StemDirection>
             <Note>
               <pitch>72</pitch>


### PR DESCRIPTION
Fixes the voicings in measure 143 of `n09op59-3_02.mscx`.   Second beat of second voice is change from dotted quarter to quarter, and the previous third voice note is moved into the second voice to fill in the space caused by the deleted augmentation dot.   A slur was also moved to the second layer and attached to the the two notes.

New rendering in Musescore:

<img width="288" alt="Screen Shot 2020-10-09 at 8 59 14 AM" src="https://user-images.githubusercontent.com/3487289/95608192-a0987580-0a11-11eb-8d2b-f6cd68c09c7a.png">
